### PR TITLE
feat(edit): enabled drag-and-drop to move cards

### DIFF
--- a/Scenes/Edit/CardEdit.tscn
+++ b/Scenes/Edit/CardEdit.tscn
@@ -6,12 +6,13 @@
 margin_right = 50.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 50, 50 )
+mouse_filter = 1
 script = ExtResource( 1 )
 
 [node name="Label" type="Label" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-mouse_filter = 0
+mouse_filter = 1
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "A"
 align = 1
@@ -21,6 +22,7 @@ valign = 1
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 custom_constants/minimum_spaces = 6
 align = 1
 max_length = 3

--- a/Scenes/Edit/DeckEdit.tscn
+++ b/Scenes/Edit/DeckEdit.tscn
@@ -83,7 +83,6 @@ size_flags_vertical = 0
 text = "+"
 
 [node name="DeleteDialogue" type="ConfirmationDialog" parent="UI"]
-visible = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/Scenes/LayoutHelpers/Column.tscn
+++ b/Scenes/LayoutHelpers/Column.tscn
@@ -13,6 +13,7 @@ script = ExtResource( 1 )
 margin_right = 200.0
 margin_bottom = 35.0
 rect_min_size = Vector2( 35, 35 )
+mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 0
 text = "+"

--- a/Scenes/LayoutHelpers/Row.tscn
+++ b/Scenes/LayoutHelpers/Row.tscn
@@ -6,6 +6,7 @@
 margin_right = 128.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 200, 50 )
+mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 0
 script = ExtResource( 1 )
@@ -14,6 +15,7 @@ script = ExtResource( 1 )
 margin_right = 25.0
 margin_bottom = 25.0
 rect_min_size = Vector2( 25, 25 )
+mouse_filter = 1
 size_flags_horizontal = 0
 size_flags_vertical = 0
 text = "+"

--- a/Scripts/Column.gd
+++ b/Scripts/Column.gd
@@ -10,6 +10,7 @@ const CardEdit = preload("res://Scenes/Edit/CardEdit.tscn")
 signal add_card_requested
 signal card_removed
 signal row_removed
+signal card_inserted
 
 var read_only = false
 
@@ -33,6 +34,9 @@ func add_card(card): # TODO use a base card here instead
 		add_row()
 	get_child(card.data.row).add_card(card)
 
+func on_row_card_inserted(card_data: CardData, row_num: int):
+	emit_signal("card_inserted", card_data, row_num)
+
 func on_row_card_removed(cardData:CardData, row:Row):
 	emit_signal("card_removed", cardData)
 	if row.is_empty:
@@ -52,6 +56,7 @@ func add_row():
 	move_child($AddRowButton, get_children().size() - 1)
 	new_row.connect("add_button_pressed", self, "add_card_to_row", [new_row])
 	new_row.connect("card_removed", self, "on_row_card_removed", [new_row])
+	new_row.connect("card_inserted", self, 'on_row_card_inserted', [new_row.get_index()])
 	is_empty = false
 
 func remove_row(row: Row):

--- a/Scripts/DeckEdit.gd
+++ b/Scripts/DeckEdit.gd
@@ -16,20 +16,20 @@ func _ready():
 	
 	$UI/DeckNameEdit.text = deck.name
 	
-	for card in deck.cards:
-		while card.column >= $UI/Columns.get_child_count() - 1:
-			add_column()
-		var newCard = CardEdit.instance()
-		newCard.data = card
-		$UI/Columns.get_child(card.column).add_card(newCard)
+	for card_data in deck.cards:
+		fill_columns(card_data)
+		var new_card = CardEdit.instance()
+		new_card.data = card_data
+		$UI/Columns.get_child(card_data.column).add_card(new_card)
 
 func add_column():
-	var newColumn = Column.instance()
-	$UI/Columns.add_child(newColumn)
+	var new_column = Column.instance()
+	$UI/Columns.add_child(new_column)
 	$UI/Columns.move_child($UI/Columns/AddColumnButton, $UI/Columns.get_child_count() - 1)
-	newColumn.connect("add_card_requested", self, "add_card_to_deck", [newColumn])
-	newColumn.connect("card_removed", self, "remove_card_from_deck")
-	newColumn.connect("row_removed", self, "handle_row_removed", [newColumn])
+	new_column.connect("add_card_requested", self, "add_empty_card_to_deck", [new_column])
+	new_column.connect("card_removed", self, "remove_card_from_deck")
+	new_column.connect("row_removed", self, "handle_row_removed", [new_column])
+	new_column.connect("card_inserted", self, "on_card_dropped_in_column", [new_column])
 
 func remove_column(column: Column):
 	var col_index = column.get_index()
@@ -39,12 +39,25 @@ func remove_column(column: Column):
 		if card.column > col_index:
 			card.column = card.column - 1
 
-func add_card_to_deck(row: int, column: Column):
+func on_card_dropped_in_column(card_data: CardData, row: int, column: Column):
+	card_data.row = row
+	card_data.column = column.get_index()
+	add_card_to_deck(card_data)
+
+func add_empty_card_to_deck(row: int, column: Column):
 	var newCardData = CardData.new("", column.get_index(), row)
-	deck.cards.append(newCardData)
+	add_card_to_deck(newCardData)
+
+func add_card_to_deck(card_data: CardData):
+	deck.cards.append(card_data)
 	var newCardEdit = CardEdit.instance()
-	newCardEdit.data = newCardData
-	$UI/Columns.get_child(column.get_index()).add_card(newCardEdit)
+	newCardEdit.data = card_data
+	fill_columns(card_data)
+	$UI/Columns.get_child(card_data.column).add_card(newCardEdit)
+
+func fill_columns(card_data: CardData):
+	while card_data.column >= $UI/Columns.get_child_count() - 1:
+		add_column()
 
 func remove_card_from_deck(card: CardData):
 	deck.cards.remove(deck.cards.find(card))

--- a/Scripts/PlayDeck.gd
+++ b/Scripts/PlayDeck.gd
@@ -17,7 +17,7 @@ func _ready():
 	$UI/DeckName.text = deck.name
 	
 	for card in deck.cards: 
-		if card.column + 1 > $UI/CardDrawer.get_child_count():
+		while card.column + 1 > $UI/CardDrawer.get_child_count():
 			columnCount += 1
 			var new_column = Column.instance()
 			new_column.read_only = true


### PR DESCRIPTION
When dragging a card:
* The current card will turn into a ghost until it is dropped
* If it is dropped inside a row, cards will move (get deleted and recreated) to place it in the spot where it is dropped
* If dropped outside a valid area, nothing will happen